### PR TITLE
Adds sync variants for compressFrame and decompressFrame

### DIFF
--- a/__test__/index.spec.ts
+++ b/__test__/index.spec.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'fs'
 
 import test from 'ava'
 
-import { compress, uncompress, compressSync, uncompressSync, compressFrame, decompressFrame } from '../index.js'
+import { compress, uncompress, compressSync, uncompressSync, compressFrame, decompressFrame, compressFrameSync, decompressFrameSync } from '../index.js'
 
 const stringToCompress = 'adewqeqweqwewleekqwoekqwoekqwpoekqwpoekqwpoekqwpoekqwpoekqwpokeeqw'
 const dict = readFileSync('__test__/dict.bin')
@@ -64,4 +64,50 @@ test('compress and decompress frame should work', async (t) => {
   t.true(before.length > compressed.length)
   const decompressed = await decompressFrame(compressed)
   t.is(before.toString('utf8'), decompressed.toString('utf8'))
+})
+
+test('compressFrameSync should return smaller value', (t) => {
+  const before = Buffer.from(stringToCompress)
+  const compressed = compressFrameSync(before)
+  t.true(before.length > compressed.length)
+  t.true(compressed.length !== 0)
+})
+
+test('compress and decompress frame sync should work', (t) => {
+  const before = Buffer.from(stringToCompress)
+  const compressed = compressFrameSync(before)
+  t.true(before.length > compressed.length)
+  const decompressed = decompressFrameSync(compressed)
+  t.is(before.toString('utf8'), decompressed.toString('utf8'))
+})
+
+test('compressFrameSync should take all input types', (t) => {
+  const stringBuffer = Buffer.from(stringToCompress)
+  t.notThrows(() => compressFrameSync(stringToCompress))
+  t.notThrows(() => compressFrameSync(stringBuffer))
+  t.notThrows(() => compressFrameSync(new Uint8Array(stringBuffer)))
+})
+
+test('decompressFrameSync should take all input types', (t) => {
+  const compressedValue = compressFrameSync(stringToCompress)
+  t.notThrows(() => decompressFrameSync(compressedValue))
+  t.notThrows(() => decompressFrameSync(new Uint8Array(compressedValue)))
+})
+
+test('frame sync and async should produce compatible output', async (t) => {
+  const before = Buffer.from(stringToCompress)
+  const compressedSync = compressFrameSync(before)
+  const compressedAsync = await compressFrame(before)
+  
+  // Both async and sync decompression should work on sync compressed data
+  const decompressedSync = decompressFrameSync(compressedSync)
+  const decompressedAsync = await decompressFrame(compressedSync)
+  t.is(before.toString('utf8'), decompressedSync.toString('utf8'))
+  t.is(before.toString('utf8'), decompressedAsync.toString('utf8'))
+  
+  // Both async and sync decompression should work on async compressed data
+  const decompressedSync2 = decompressFrameSync(compressedAsync)
+  const decompressedAsync2 = await decompressFrame(compressedAsync)
+  t.is(before.toString('utf8'), decompressedSync2.toString('utf8'))
+  t.is(before.toString('utf8'), decompressedAsync2.toString('utf8'))
 })

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,8 +5,10 @@ export declare function compress(
   dict?: string | Buffer | undefined | null,
 ): Promise<Buffer> | Promise<Buffer>
 export declare function compressFrame(data: string | Buffer): Promise<Buffer>
+export declare function compressFrameSync(data: string | Buffer): Buffer
 export declare function compressSync(data: string | Buffer, dict?: string | Buffer | undefined | null): Buffer
 export declare function decompressFrame(data: string | Buffer): Promise<Buffer>
+export declare function decompressFrameSync(data: string | Buffer): Buffer
 export declare function uncompress(
   data: string | Buffer,
   dict?: string | Buffer | undefined | null,

--- a/index.js
+++ b/index.js
@@ -363,7 +363,9 @@ if (!nativeBinding) {
 
 module.exports.compress = nativeBinding.compress
 module.exports.compressFrame = nativeBinding.compressFrame
+module.exports.compressFrameSync = nativeBinding.compressFrameSync
 module.exports.compressSync = nativeBinding.compressSync
 module.exports.decompressFrame = nativeBinding.decompressFrame
+module.exports.decompressFrameSync = nativeBinding.decompressFrameSync
 module.exports.uncompress = nativeBinding.uncompress
 module.exports.uncompressSync = nativeBinding.uncompressSync


### PR DESCRIPTION
While trying to get a Kafka library working, I realized that I needed the LZ4 frame decompression, not the standard LZ4 compression, and their existing implementation only runs sync for compression/decompression, so I wanted to expose these variants.

Please let me know if you have any feedback!