### PR TITLE
fix: build mimalloc for the ARMv8.0 baseline on arm64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,27 @@ napi-derive = "3"
 # aarch64-pc-windows-msvc (undeclared __ldar64/__stlr64 intrinsics) and
 # segfaults at runtime on s390x. Pin both crates to the versions that were
 # green on main until upstream fixes the regressions.
+#
+# no_opt_arch: mimalloc's CMake defaults MI_OPT_ARCH=ON on arm64, which adds
+# `-march=armv8.1-a` and inlines LSE atomics. Those are optional in ARMv8.0, so
+# the resulting binaries die with an illegal instruction on chips like the
+# Cortex-A73 (see #705). Turning it off drops mimalloc back to the ARMv8.0
+# baseline. Android lands in the first block (target_os = "android"), and old
+# ARMv8.0 phones are exactly the hardware at risk, so both blocks need it.
 [target.'cfg(all(not(target_os = "linux"), not(target_family = "wasm")))'.dependencies]
-mimalloc-safe    = { version = "=0.1.54", features = ["skip_collect_on_exit"] }
 libmimalloc-sys2 = "=0.1.50"
+mimalloc-safe = { version = "=0.1.54", features = [
+  "skip_collect_on_exit",
+  "no_opt_arch",
+] }
 
 [target.'cfg(all(target_os = "linux", not(target_env = "ohos"), not(target_env = "musl")))'.dependencies]
-mimalloc-safe    = { version = "=0.1.54", features = ["local_dynamic_tls", "skip_collect_on_exit"] }
 libmimalloc-sys2 = "=0.1.50"
+mimalloc-safe = { version = "=0.1.54", features = [
+  "local_dynamic_tls",
+  "skip_collect_on_exit",
+  "no_opt_arch",
+] }
 
 [build-dependencies]
 napi-build = "2"


### PR DESCRIPTION
Fixes #705.

## The problem

The crash isn't in lz4 — it's in mimalloc.

mimalloc's bundled `CMakeLists.txt` defaults `MI_OPT_ARCH=ON` on arm64:

```cmake
elseif(MI_ARCH STREQUAL "arm64")
  set(MI_OPT_ARCH "ON")  # enable armv8.1-a by default on arm64 unless MI_NO_OPT_ARCH is set
```

which adds `-march=armv8.1-a` and inlines LSE atomics. LSE is *optional* in ARMv8.0, so the binary dies with an illegal instruction on ARMv8.0 hardware — before any lz4 code runs. The reporter's Cortex-A73 (`Features: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid`, no `atomics`) hits it during allocator init.

Disassembling the published `lz4-napi-linux-arm64-gnu@2.9.1` reproduces their trace exactly:

```
6208c: f8e80128    ldaddal x8, x8, [x9]     <_mi_options_init+28>
```

## The fix

Enable the `no_opt_arch` feature, which sets `MI_NO_OPT_ARCH=ON` and drops mimalloc back to the ARMv8.0 baseline.

Both dependency blocks need it: Android is `target_os = "android"`, so it resolves to the `not(target_os = "linux")` block, and old ARMv8.0 phones are the likeliest affected hardware. macOS and Windows on ARM are unaffected either way — their compiler baselines already include LSE, so the flag is a no-op there.

## Verification

Built `aarch64-unknown-linux-gnu` natively on arm64 Linux and attributed every LSE instruction to its enclosing symbol. LSE inside `__aarch64_*` outline-atomic helpers is safe (those check HWCAP at runtime); anything else is not.

| | LSE total | reachable without runtime dispatch |
|---|---|---|
| as shipped (2.9.1) | 173 | **160** |
| with `no_opt_arch` | 18 | **0** |

The 160 are spread across the allocation paths — `_mi_malloc_generic`, `mi_find_page`, `mi_free_block_delayed_mt`, `_mi_bitmap_claim_across`, `mi_stats_merge_from`, `_mi_options_init` and others — so this is not confined to init.

Checked under both **gcc 12** and **clang 14**; both give 0 after the fix. gcc falls back to outline atomics, clang to `ldxr`/`stxr`.

`yarn test` — 13/13 pass.

## Performance

Benchmarked both builds on arm64 Linux, median of 7 per sample, 4 independent runs each:

| case | shipped | `no_opt_arch` | delta |
|---|---|---|---|
| compressSync (248KB) | 7,525 op/s ±13.4% | 7,629 ±3.5% | +1.38% |
| uncompressSync (248KB) | 19,333 ±8.9% | 18,580 ±0.9% | −3.90% |
| compressSync (1KB churn) | 770,032 ±29.6% | 761,768 ±8.0% | −1.07% |
| compress async (248KB) | 26,345 ±1.2% | 25,830 ±0.6% | −1.95% |
| compress async (1KB) | 404,903 ±3.7% | 414,985 ±5.2% | +2.49% |

Deltas land inside the run-to-run spread — not measurable above noise.

That matches what the allocator is actually worth here: removing mimalloc *entirely* in favour of system malloc moves this workload by only −5% to +4.6%. mimalloc's fast paths (thread-local free list, same-thread free) use no atomics at all; they only appear on cross-thread frees and page acquisition, and lz4-napi does ~1–2 allocations per call. In isolation the instruction swap costs +1.6 ns/op uncontended and +4.8 ns at 4 threads — a rounding error against a 1.09 µs (1KB) or 136 µs (248KB) call.

## Possible follow-up

Rather than dropping to the baseline, mimalloc could be built with `-moutline-atomics`, keeping LSE on capable chips via runtime dispatch while staying safe on ARMv8.0. gcc already does this by default; clang would need the flag passed explicitly. Given the numbers above there's nothing measurable to recover, so this keeps the simple fix.