### PR TITLE
fix: Version 2.9.1 includes opcodes not supported on all ARM64 processors

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,9 +4,12 @@ rustflags = [
   "target-feature=-crt-static",
 ]
 
+[target.aarch64-unknown-linux-gnu]
+rustflags = ["-C", "target-feature=-atomics"]
+
 [target.aarch64-unknown-linux-musl]
 linker = "aarch64-linux-musl-gcc"
-rustflags = ["-C", "target-feature=-crt-static"]
+rustflags = ["-C", "target-feature=-crt-static", "-C", "target-feature=-atomics"]
 
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
Closes #705